### PR TITLE
feat: :sparkles: no cookie property

### DIFF
--- a/src/main/java/com/strandls/user/Constants.java
+++ b/src/main/java/com/strandls/user/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
 	public static final String BA_TOKEN = "BAToken";
 	public static final String BR_TOKEN = "BRToken";
 	public static final String REFRESH_TOKEN = "refresh_token";
+	public static final String NO_COOKIE = "no_cookie";
 
 	public static final String OBSERVATION = "observation";
 	public static final String SPECIES_PARTICIPATION_OBSERVATION = "species.participation.Observation";

--- a/src/main/java/com/strandls/user/controller/AuthenticationController.java
+++ b/src/main/java/com/strandls/user/controller/AuthenticationController.java
@@ -125,7 +125,8 @@ public class AuthenticationController {
 			boolean status = Boolean.parseBoolean(tokens.get(Constants.STATUS).toString());
 			boolean verification = Boolean.parseBoolean(tokens.get("verificationRequired").toString());
 			ResponseBuilder response = Response.ok().entity(tokens);
-			if (status && !verification) {
+			String noCookie = PropertyFileUtil.fetchProperty("config.properties", Constants.NO_COOKIE);
+			if (status && !verification && noCookie.equals("0")) {
 				NewCookie accessToken = new NewCookie(Constants.BA_TOKEN, tokens.get(Constants.ACCESS_TOKEN).toString(),
 						"/", AppUtil.getDomain(request), "", 10 * 24 * 60 * 60,false);//NOSONAR
 				NewCookie refreshToken = new NewCookie(Constants.BR_TOKEN,
@@ -158,10 +159,15 @@ public class AuthenticationController {
 			// tokens
 			Map<String, Object> tokens = this.authenticationService.buildTokens(profile,
 					this.userService.fetchUser(Long.parseLong(profile.getId())), true);
-			return Response.status(Status.OK)
+
+			String noCookie = PropertyFileUtil.fetchProperty("config.properties", Constants.NO_COOKIE);
+			if(noCookie.equals("0")) {
+				return Response.status(Status.OK)
 					.cookie(new NewCookie(Constants.BA_TOKEN, tokens.get(Constants.ACCESS_TOKEN).toString()))
 					.cookie(new NewCookie(Constants.BR_TOKEN, tokens.get(Constants.REFRESH_TOKEN).toString()))
 					.entity(tokens).build();
+			}
+			return Response.status(Status.OK).entity(tokens).build();
 		} catch (Exception ex) {
 			logger.error(ex.getMessage());
 			return Response.status(Status.BAD_REQUEST).entity(ex.getMessage()).build();
@@ -274,7 +280,8 @@ public class AuthenticationController {
 			return Response.status(Status.BAD_REQUEST).entity("OTP Cannot be empty").build();
 		}
 		Map<String, Object> result = authenticationService.validateUser(request, id, otp);
-		if (Boolean.parseBoolean(result.get(Constants.STATUS).toString())) {
+		String noCookie = PropertyFileUtil.fetchProperty("config.properties", Constants.NO_COOKIE);
+		if (Boolean.parseBoolean(result.get(Constants.STATUS).toString()) && noCookie.equals("0")) {
 			NewCookie accessToken = new NewCookie(Constants.BA_TOKEN, result.get(Constants.ACCESS_TOKEN).toString(),
 					"/", AppUtil.getDomain(request), "", 10 * 24 * 60 * 60, false);//NOSONAR
 			NewCookie refreshToken = new NewCookie(Constants.BR_TOKEN, result.get(Constants.REFRESH_TOKEN).toString(),

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,6 +2,7 @@ version=1.0
 title=User Module MicroServices
 schemes=http
 host=localhost:8080
+no_cookie=0
 basePath=/user-api/api
 resourcePackage=com.strandls.user
 prettyPrint=true


### PR DESCRIPTION
by default multi-domain cookie is set like signing on indiabiodiversity.org will carry same authincation to it's subdomain i.e. `treesindia.indiabiodiversity.org`

but when there are two different instances deployed on same domain i.e. `cca.org` and `stag.cca.org` cookie generates a conflict due to different signing secret so for only single domain portals we can disable sending cookie back when signing in since UI does that job automatically

this property flag is by default disabled can be enabled via modifying `config.properties` and setting `no_cookie=1`